### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Creates a DC/OS network for GCP for Masters and Agents
 ```hcl
 module "dcos-vpc" {
   source  = "dcos-terraform/network/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   agent_cidr_range = "10.65.0.0/16"
   master_cidr_range = "10.64.0.0/16"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  * ```hcl
  * module "dcos-vpc" {
  *   source  = "dcos-terraform/network/gcp"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   agent_cidr_range = "10.65.0.0/16"
  *   master_cidr_range = "10.64.0.0/16"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2