### PR TITLE
Change modules/resources to use google-beta provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,11 +17,13 @@
  * ```
  */
 
-provider "google" {}
+provider "google-beta" {}
 
 resource "google_compute_network" "network" {
   name                    = "${var.cluster_name}-network"
   auto_create_subnetworks = "false"
+
+  provider = "google-beta"
 }
 
 ## Two subnetworks (masters, agents)
@@ -29,10 +31,14 @@ resource "google_compute_subnetwork" "master-subnet" {
   name          = "${var.cluster_name}-master-subnet"
   ip_cidr_range = "${var.master_cidr_range}"
   network       = "${google_compute_network.network.self_link}"
+
+  provider = "google-beta"
 }
 
 resource "google_compute_subnetwork" "agent-subnet" {
   name          = "${var.cluster_name}-agent-subnet"
   ip_cidr_range = "${var.agent_cidr_range}"
   network       = "${google_compute_network.network.self_link}"
+
+  provider = "google-beta"
 }


### PR DESCRIPTION
In order to not require pinning to an older version of the terraform provider (dcos-terraform/terraform-gcp-dcos#24) the options appear to be 1) remove usage of beta features or 2) move to the google-beta provider. This PR is an attempt at option 2.